### PR TITLE
Allow setting leeway on timestamp-based claims (i.e. iat, exp, nbf). …

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ If both `public-key` and `jwks-uri` are set, the `jwks-uri` takes precedence and
 
 JWT authentication can be disabled by setting the `kumuluzee.jwt-auth.enabled` configuration property to `false`.
 
+You can configure the maximum leeway the authenticator allows for timestamp claims (such as _nbf_ or _iat_) by
+setting `kumuluzee.jwt-auth.maximum-leeway`. The default value is `5`, meaning five seconds.
+
 ##  Accessing token information
 
 There are multiple ways with which you can access the decoded token data. The standard way is to access the principal 

--- a/src/main/java/com/kumuluz/ee/jwt/auth/cdi/JWTContextInfo.java
+++ b/src/main/java/com/kumuluz/ee/jwt/auth/cdi/JWTContextInfo.java
@@ -63,6 +63,8 @@ public class JWTContextInfo {
 
     private String issuer;
 
+    private int maximumLeeway;
+
     @PostConstruct
     public void init() {
         ConfigurationUtil config = ConfigurationUtil.getInstance();
@@ -120,6 +122,8 @@ public class JWTContextInfo {
         issuer = config.get("mp.jwt.verify.issuer")
                 .orElse(config.get("kumuluzee.jwt-auth.issuer").orElse(null));
 
+        maximumLeeway = Integer.parseInt(config.get("kumuluzee.jwt-auth.maximum-leeway").orElse("5"));
+
         initJwks();
     }
 
@@ -155,6 +159,14 @@ public class JWTContextInfo {
 
     public void setIssuer(String issuer) {
         this.issuer = issuer;
+    }
+
+    public int getMaximumLeeway() {
+        return maximumLeeway;
+    }
+
+    public void setMaximumLeeway(int maximumLeeway) {
+        this.maximumLeeway = maximumLeeway;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/kumuluz/ee/jwt/auth/validator/JWTValidator.java
+++ b/src/main/java/com/kumuluz/ee/jwt/auth/validator/JWTValidator.java
@@ -57,7 +57,10 @@ public class JWTValidator {
             }
         }
 
-        JWTVerifier verifier = JWT.require(algorithm).withIssuer(jwtContextInfo.getIssuer()).build();
+        JWTVerifier verifier = JWT.require(algorithm)
+                .withIssuer(jwtContextInfo.getIssuer())
+                .acceptLeeway(jwtContextInfo.getMaximumLeeway())
+                .build();
 
         DecodedJWT jwt;
         try {


### PR DESCRIPTION
…Default set to 5 seconds.